### PR TITLE
Enable IntelliJ 2023.2 EAP

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ tasks {
 
     patchPluginXml {
         sinceBuild.set("221.*")
-        untilBuild.set("231.*")
+        untilBuild.set("232.*")
     }
 
     signPlugin {


### PR DESCRIPTION
Plugin must be defined as compatible to work in the new EAP versions. I tried it locally, works as well as in the stable versions.