### PR TITLE
Added "Replace" action for when the private key is not available

### DIFF
--- a/src/main/java/com/github/daputzy/intellijsopsplugin/SopsNotificationProvider.java
+++ b/src/main/java/com/github/daputzy/intellijsopsplugin/SopsNotificationProvider.java
@@ -3,6 +3,7 @@ package com.github.daputzy.intellijsopsplugin;
 import java.util.function.Function;
 
 import com.github.daputzy.intellijsopsplugin.handler.EditActionHandler;
+import com.github.daputzy.intellijsopsplugin.handler.ReplaceActionHandler;
 import com.github.daputzy.intellijsopsplugin.sops.DetectionUtil;
 import com.intellij.openapi.fileEditor.FileEditor;
 import com.intellij.openapi.project.Project;
@@ -29,6 +30,7 @@ public class SopsNotificationProvider implements EditorNotificationProvider {
 
 			panel.setText("Sops file detected");
 			panel.createActionLabel("Edit", new EditActionHandler(project, file)::handle);
+			panel.createActionLabel("Replace", new ReplaceActionHandler(project, file)::handle);
 
 			return panel;
 		};

--- a/src/main/java/com/github/daputzy/intellijsopsplugin/SopsReplaceAction.java
+++ b/src/main/java/com/github/daputzy/intellijsopsplugin/SopsReplaceAction.java
@@ -1,0 +1,42 @@
+package com.github.daputzy.intellijsopsplugin;
+
+import com.github.daputzy.intellijsopsplugin.handler.ReplaceActionHandler;
+import com.github.daputzy.intellijsopsplugin.sops.DetectionUtil;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+
+public class SopsReplaceAction extends AnAction {
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        final Project project = e.getProject();
+        final VirtualFile file = e.getData(CommonDataKeys.VIRTUAL_FILE);
+
+        if (project == null || file == null) {
+            throw new IllegalStateException();
+        }
+
+        final ReplaceActionHandler actionHandler = new ReplaceActionHandler(project, file);
+        actionHandler.handle();
+    }
+
+    @Override
+    public void update(@NotNull AnActionEvent e) {
+        e.getPresentation().setEnabled(false);
+
+        final Project project = e.getProject();
+        final VirtualFile file = e.getData(CommonDataKeys.VIRTUAL_FILE);
+
+        if (project == null || file == null) {
+            return;
+        }
+
+        if (DetectionUtil.getInstance().sopsFileDetected(project, file)) {
+            e.getPresentation().setEnabled(true);
+        }
+    }
+}

--- a/src/main/java/com/github/daputzy/intellijsopsplugin/handler/ReplaceActionHandler.java
+++ b/src/main/java/com/github/daputzy/intellijsopsplugin/handler/ReplaceActionHandler.java
@@ -1,0 +1,62 @@
+package com.github.daputzy.intellijsopsplugin.handler;
+
+import com.github.daputzy.intellijsopsplugin.file.FileUtil;
+import com.github.daputzy.intellijsopsplugin.sops.ExecutionUtil;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.fileEditor.FileEditorManagerListener;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.testFramework.LightVirtualFile;
+import com.intellij.util.messages.MessageBusConnection;
+import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
+
+@RequiredArgsConstructor
+public class ReplaceActionHandler {
+
+    @NotNull
+    private final Project project;
+
+    @NotNull
+    private final VirtualFile file;
+
+    public void handle() {
+        final String originalContent = FileUtil.getInstance().getContent(file);
+        final String emptyContent = "";
+        final VirtualFile inMemoryFile = new LightVirtualFile(
+                file.getName(),
+                FileUtil.getInstance().getFileType(file),
+                emptyContent
+        );
+
+        ApplicationManager.getApplication()
+                .invokeLater(() -> FileEditorManager.getInstance(project).openFile(inMemoryFile, true));
+
+        final MessageBusConnection connection = project.getMessageBus().connect();
+        connection.subscribe(FileEditorManagerListener.FILE_EDITOR_MANAGER, new FileEditorManagerListener() {
+            @Override
+            public void fileClosed(@NotNull FileEditorManager source, @NotNull VirtualFile closedFile) {
+                if (inMemoryFile.equals(closedFile)) {
+                    // check if it is our file first, other files may not have a document
+                    final String closedFileContent = FileUtil.getInstance().getDocument(closedFile).getText();
+
+                    if (!closedFileContent.equals(emptyContent)) {
+                        FileUtil.getInstance().writeContentBlocking(file, closedFileContent);
+
+                        ExecutionUtil.getInstance().encrypt(
+                                project,
+                                file,
+                                // success
+                                () -> file.refresh(true, false),
+                                // failure
+                                () -> FileUtil.getInstance().writeContentBlocking(file, originalContent)
+                        );
+
+                        connection.disconnect();
+                    }
+                }
+            }
+        });
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -45,6 +45,8 @@
 	<actions>
 		<action id="com.github.daputzy.intellijsopsplugin.SopsEditAction"
 			class="com.github.daputzy.intellijsopsplugin.SopsEditAction" text="Simple Sops Edit"/>
+		<action id="com.github.daputzy.intellijsopsplugin.SopsReplaceAction"
+				class="com.github.daputzy.intellijsopsplugin.SopsReplaceAction" text="Simple Sops Edit and Replace"/>
 	</actions>
 
 	<applicationListeners>


### PR DESCRIPTION
The "Replace" action works the same as the existing "Edit" action. 

The difference is that the decrypt step is skipped and an empty editor is opened instead.