### PR TITLE
Update for IDEA 2024.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ tasks {
 
     patchPluginXml {
         sinceBuild.set("231.8109.175")
-        untilBuild.set("241.*")
+        untilBuild.set("242.*")
     }
 
     signPlugin {


### PR DESCRIPTION
As always, we need a version bump to enable running the plugin on the new EAP version.