### PR TITLE
Add support for WSL distributions

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,9 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <codeStyleSettings language="JAVA">
+      <indentOptions>
+        <option name="USE_TAB_CHARACTER" value="true" />
+      </indentOptions>
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/src/main/java/com/github/daputzy/intellijsopsplugin/settings/SettingsConfigurable.java
+++ b/src/main/java/com/github/daputzy/intellijsopsplugin/settings/SettingsConfigurable.java
@@ -35,6 +35,8 @@ public class SettingsConfigurable implements Configurable {
 
 		return !Objects.equals(settings.sopsEnvironment, settingsComponent.getSopsEnvironment()) ||
 			!Objects.equals(settings.sopsExecutable, settingsComponent.getSopsExecutable()) ||
+			!Objects.equals(settings.sopsUseWSL, settingsComponent.getSopsUseWSL()) ||
+			!Objects.equals(settings.sopsWslDistributionName, settingsComponent.getSopsWslDistributionName()) ||
 			!Objects.equals(settings.sopsFilesReadOnly, settingsComponent.getSopsFilesReadOnly());
 	}
 
@@ -44,6 +46,8 @@ public class SettingsConfigurable implements Configurable {
 
 		settings.sopsEnvironment = settingsComponent.getSopsEnvironment();
 		settings.sopsExecutable = settingsComponent.getSopsExecutable();
+		settings.sopsUseWSL = settingsComponent.getSopsUseWSL();
+		settings.sopsWslDistributionName = settingsComponent.getSopsWslDistributionName();
 		settings.sopsFilesReadOnly = settingsComponent.getSopsFilesReadOnly();
 	}
 
@@ -53,6 +57,8 @@ public class SettingsConfigurable implements Configurable {
 
 		settingsComponent.setSopsEnvironment(settings.sopsEnvironment);
 		settingsComponent.setSopsExecutable(settings.sopsExecutable);
+		settingsComponent.setSopsUseWSL(settings.sopsUseWSL);
+		settingsComponent.setSopsWslDistributionName(settings.sopsWslDistributionName);
 		settingsComponent.setSopsFilesReadOnly(settings.sopsFilesReadOnly);
 	}
 

--- a/src/main/java/com/github/daputzy/intellijsopsplugin/settings/SettingsState.java
+++ b/src/main/java/com/github/daputzy/intellijsopsplugin/settings/SettingsState.java
@@ -1,12 +1,17 @@
 package com.github.daputzy.intellijsopsplugin.settings;
 
+import com.intellij.execution.wsl.WSLDistribution;
+import com.intellij.execution.wsl.WslDistributionManager;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
 import com.intellij.util.xmlb.XmlSerializerUtil;
+import com.intellij.util.xmlb.annotations.Transient;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
 
 @State(
 	name = "com.github.daputzy.intellijsopsplugin.settings.SettingsState",
@@ -15,8 +20,21 @@ import org.jetbrains.annotations.Nullable;
 public class SettingsState implements PersistentStateComponent<SettingsState> {
 
 	public String sopsExecutable = "sops";
+	public boolean sopsUseWSL = false;
 	public boolean sopsFilesReadOnly = false;
 	public String sopsEnvironment = "";
+	public String sopsWslDistributionName = null;
+	@Transient
+	private WSLDistribution sopsWslDistribution = null;
+
+	public Optional<WSLDistribution> tryGetWslDistribution() {
+		if (sopsWslDistribution != null) return Optional.of(sopsWslDistribution);
+		Optional<WSLDistribution> distribution = WslDistributionManager.getInstance().getInstalledDistributions().stream()
+				.filter(d -> d.getPresentableName().equals(sopsWslDistributionName))
+				.findFirst();
+		distribution.ifPresent(d -> sopsWslDistribution = d);
+		return distribution;
+	}
 
 	public static SettingsState getInstance() {
 		return ApplicationManager.getApplication().getService(SettingsState.class);

--- a/src/main/java/com/github/daputzy/intellijsopsplugin/sops/ExecutionUtil.java
+++ b/src/main/java/com/github/daputzy/intellijsopsplugin/sops/ExecutionUtil.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -11,11 +13,10 @@ import java.util.function.Predicate;
 import com.github.daputzy.intellijsopsplugin.settings.SettingsState;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
-import com.intellij.execution.process.OSProcessHandler;
-import com.intellij.execution.process.ProcessAdapter;
-import com.intellij.execution.process.ProcessEvent;
-import com.intellij.execution.process.ProcessListener;
-import com.intellij.execution.process.ProcessOutputType;
+import com.intellij.execution.process.*;
+import com.intellij.execution.wsl.*;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -48,6 +49,7 @@ public class ExecutionUtil {
 		command.addParameter(file.getName());
 
 		run(
+			project,
 			command,
 			new ErrorNotificationProcessListener(project),
 			new ProcessAdapter() {
@@ -91,6 +93,7 @@ public class ExecutionUtil {
 		command.addParameter(file.getName());
 
 		run(
+			project,
 			command,
 			new ErrorNotificationProcessListener(project),
 			new ProcessAdapter() {
@@ -122,66 +125,99 @@ public class ExecutionUtil {
 		final Runnable successHandler,
 		final Runnable failureHandler
 	) {
-		final ScriptUtil.ScriptFiles scriptFiles = ScriptUtil.getInstance().createScriptFiles();
 
-		final GeneralCommandLine command = buildCommand(file.getParent().getPath());
+		new Task.Backgroundable(project, "Opening editor for " + file.getName(), false) {
 
-		final String editorPath = scriptFiles.script().toAbsolutePath().toString()
-			// escape twice for windows because of ENV variable parsing
-			.replace("\\", "\\\\")
-			// escape whitespaces
-			.replace(" ", "\\ ");
+			@Override
+			public void run(@NotNull ProgressIndicator progressIndicator) {
 
-		command.withEnvironment("EDITOR", editorPath);
-		command.addParameter(file.getName());
+				final ScriptUtil.ScriptFiles scriptFiles = ScriptUtil.getInstance().createScriptFiles();
 
-		run(
-			command,
-			new ErrorNotificationProcessListener(project),
-			new ProcessAdapter() {
-				private final AtomicBoolean failed = new AtomicBoolean(false);
+				final GeneralCommandLine command = buildCommand(file.getParent().getPath());
 
-				@Override
-				public void processTerminated(@NotNull final ProcessEvent event) {
-					// clean up the temporary files
-					FileUtils.deleteQuietly(scriptFiles.directory().toFile());
 
-					if (event.getExitCode() == 0 && !failed.get()) {
-						successHandler.run();
-					} else {
-						failureHandler.run();
-					}
+				final String editorPath;
+				final String rawPath = scriptFiles.script().toAbsolutePath().toString();
+				if (WslPath.isWslUncPath(rawPath)) {
+					editorPath = Objects.requireNonNull(WslPath.parseWindowsUncPath(rawPath)).getLinuxPath();
+				} else {
+					editorPath = rawPath
+							// escape twice for windows because of ENV variable parsing
+							.replace("\\", "\\\\")
+							// escape whitespaces
+							.replace(" ", "\\ ");
 				}
 
-				@Override
-				@SneakyThrows(IOException.class)
-				public void onTextAvailable(@NotNull final ProcessEvent event, @NotNull final Key outputType) {
-					if (null != event.getText() && ScriptUtil.INPUT_START_IDENTIFIER.equals(event.getText().trim())) {
-						IOUtils.write(newContent, event.getProcessHandler().getProcessInput(), file.getCharset());
-						event.getProcessHandler().getProcessInput().close();
-					}
+				command.withEnvironment("EDITOR", editorPath);
+				command.addParameter(file.getName());
 
-					if (ProcessOutputType.isStderr(outputType)) {
-						event.getProcessHandler().destroyProcess();
-						// destroy process is apparently perfectly fine and exit code is 0
-						failed.set(true);
-					}
-				}
+				ExecutionUtil.this.run(
+					project,
+					command,
+					new ErrorNotificationProcessListener(project),
+					new
+
+							ProcessAdapter() {
+								private final AtomicBoolean failed = new AtomicBoolean(false);
+
+								@Override
+								public void processTerminated(@NotNull final ProcessEvent event) {
+									// clean up the temporary files
+									FileUtils.deleteQuietly(scriptFiles.directory().toFile());
+
+									if (event.getExitCode() == 0 && !failed.get()) {
+										successHandler.run();
+									} else {
+										failureHandler.run();
+									}
+								}
+
+								@Override
+								@SneakyThrows(IOException.class)
+								public void onTextAvailable(@NotNull final ProcessEvent event, @NotNull final Key outputType) {
+									if (null != event.getText() && ScriptUtil.INPUT_START_IDENTIFIER.equals(event.getText().trim())) {
+										IOUtils.write(newContent, event.getProcessHandler().getProcessInput(), file.getCharset());
+										event.getProcessHandler().getProcessInput().close();
+									}
+
+									if (ProcessOutputType.isStderr(outputType)) {
+										event.getProcessHandler().destroyProcess();
+										// destroy process is apparently perfectly fine and exit code is 0
+										failed.set(true);
+									}
+								}
+							}
+
+				);
 			}
-		);
+		}.queue();
 	}
 
-	private void run(final GeneralCommandLine command, final ProcessListener... listener) {
-		final OSProcessHandler processHandler;
-		try {
-			processHandler = new OSProcessHandler(command);
-		} catch (final ExecutionException e) {
-			throw new RuntimeException("Could not execute sops command", e);
-		}
+	private void run(final Project project, final GeneralCommandLine command, final ProcessListener... listener) {
+		new Task.Backgroundable(project, "Running " + command.getCommandLineString(), false) {
+			@Override
+			public void run(@NotNull ProgressIndicator progressIndicator) {
+				final ProcessHandler processHandler;
+				try {
+					if (SettingsState.getInstance().sopsUseWSL) {
+						WSLDistribution distro = SettingsState.getInstance().tryGetWslDistribution().orElseThrow();
+						WSLCommandLineOptions options = new WSLCommandLineOptions();
+						distro.patchCommandLine(command, null, options);
+						processHandler = new CapturingProcessHandler(command);
+					} else {
+						processHandler = new OSProcessHandler(command);
+					}
+				} catch (final ExecutionException e) {
+					throw new RuntimeException("Could not execute sops command", e);
+				} catch (NoSuchElementException e) {
+					throw new RuntimeException("Unable to locate WSL distribution of name " + SettingsState.getInstance().sopsWslDistributionName, e);
+				}
 
-		Arrays.stream(listener).forEach(processHandler::addProcessListener);
+				Arrays.stream(listener).forEach(processHandler::addProcessListener);
 
-		processHandler.startNotify();
+				processHandler.startNotify();
+			}
+		}.queue();
 	}
 
 	private GeneralCommandLine buildCommand(final String cwd) {


### PR DESCRIPTION
If your project relies inside WSL, this is needed in order for the plugin to understand the path, as UNC paths do not translate within commandline, they only work inside of UI elements.